### PR TITLE
Fixed styling issue of view on github button

### DIFF
--- a/Women-on-Github/web/css/styles.css
+++ b/Women-on-Github/web/css/styles.css
@@ -547,7 +547,6 @@ a img{
 .user-img {
   position: relative;
   display: block;
-  height: 100%;
 }
 .mdl-button--fab {
   position:absolute;


### PR DESCRIPTION
Currently:
![image](https://cloud.githubusercontent.com/assets/7105293/18765872/27aa1052-8135-11e6-90a5-ad300d187f62.png)

Now (after small fix)
![image](https://cloud.githubusercontent.com/assets/7105293/18765844/13241916-8135-11e6-9ef6-6e7c77f244b0.png)
